### PR TITLE
fix: add LocalStack license requirement and standardize setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+export AWS_ACCESS_KEY_ID ?= test
+export AWS_SECRET_ACCESS_KEY ?= test
+export AWS_DEFAULT_REGION=us-east-1
+SHELL := /bin/bash
+
+usage:		## Show this help
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$//' | sed -e 's/##//'
+
+install:	## Install dependencies
+	@which localstack || pip install localstack
+	@which awslocal || pip install awscli-local
+
+start:		## Start LocalStack
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+
+stop:		## Stop LocalStack
+	@localstack stop
+
+ready:		## Wait until LocalStack is ready
+	@echo Waiting on the LocalStack container...
+	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+
+logs:		## Save the logs in a separate file
+	@localstack logs > logs.txt
+
+.PHONY: usage install start stop ready logs

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ make start
 make ready
 ```
 
-Alternatively, you can start LocalStack using docker compose:
+Alternatively, you can start LocalStack using Docker compose:
 
 ```bash
 cd localstack

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Ollama. We will start off by creating the entire stack locally  with LocalStack,
 
 ## Prerequisites
 
-- [AWS free tier account](https://aws.amazon.com/free/)
-- [LocalStack](https://localstack.cloud/)
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 - [Docker](https://docs.docker.com/get-docker/) - for running LocalStack
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and [AWS CLI local](https://github.com/localstack/awscli-local)
 - [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) - for building the frontend app
@@ -81,8 +81,15 @@ computation and memory footprint. Depending on your needs, you can replace it wi
 
 ### Starting LocalStack
 
-First thing we need to do is start LocalStack by using docker compose. This permits an easy visualisation of all the necessary configs.
-Remember to set your `LOCALSTACK_AUTH_TOKEN` as an environment variable.
+First thing we need to do is start LocalStack. Remember to set your `LOCALSTACK_AUTH_TOKEN` as an environment variable.
+
+```bash
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
+make start
+make ready
+```
+
+Alternatively, you can start LocalStack using docker compose:
 
 ```bash
 cd localstack


### PR DESCRIPTION
## Summary

- Create Makefile with standard targets and auth guard for `LOCALSTACK_AUTH_TOKEN`
- Add license bullet to Prerequisites and update start section in README
